### PR TITLE
dodano skrypt logujący się do bazy danych

### DIFF
--- a/src/php/login-mysql.php
+++ b/src/php/login-mysql.php
@@ -1,0 +1,18 @@
+<?php
+
+# ustawienia połączenia z bazą danych
+
+$serverName = "localhost";
+$userName = "root";
+$password = "";
+$db_name = "politycy";
+
+# utworzenie połączenia z bazą danych o nazwie conn
+
+$conn = new mysqli($serverName, $userName, $password, $db_name);
+
+# sprawdzenie poprawności połączenia
+
+if ($conn->connect_error) {
+  die("Connection failed: " . $conn->connect_error);
+}


### PR DESCRIPTION
Skrypt należy dodawać do podstron które potrzebują dostępu do bazy danych za pomocą 
`<?php include /php/login-mysql.php ?>` 